### PR TITLE
Fix associations being cleared before a record is initially saved

### DIFF
--- a/spec/lib/acts_as_taggable_spec.rb
+++ b/spec/lib/acts_as_taggable_spec.rb
@@ -142,6 +142,21 @@ describe 'acts_as_taggable' do
       expect(record.tags.collect(&:name)).to contain_exactly('red', 'green')
     end
 
+    it 'creates with an array of strings and sets the tags tag match' do
+      record = klass.create!(:tag_names => ['red', 'green'])
+      expect(record.tags.collect(&:name)).to contain_exactly('red', 'green')
+    end
+
+    it 'updates with different tags' do
+      record.update!(:tag_names => ['blue', 'green'])
+      expect(record.tags.collect(&:name)).to contain_exactly('blue', 'green')
+    end
+
+    it 'updates with no tags' do
+      record.update!(:tag_names => [])
+      expect(record.tags.collect(&:name)).to be_empty
+    end
+
     it 'ignores empty strings' do
       record.tag_names = ['', 'green']
       expect(record.tags.collect(&:name)).to contain_exactly('green')

--- a/spec/lib/tag_scoping_spec.rb
+++ b/spec/lib/tag_scoping_spec.rb
@@ -74,6 +74,14 @@ describe 'acts_as_taggable' do
       record.material_tags = [metal]
       expect(record.tags).to contain_exactly(red, metal)
     end
+
+    it 'resets the unscoped tags association when tags are removed' do
+      record.material_tags = [metal]
+      expect(record.tags).to contain_exactly(metal)
+
+      record.material_taggings = []
+      expect(record.tags).to be_empty
+    end
   end
 
   describe '#tag_type_taggings' do
@@ -91,7 +99,6 @@ describe 'acts_as_taggable' do
       expect(record.taggings.collect(&:tag)).to contain_exactly(red, metal, wood)
     end
   end
-
 
   describe '#tag_type_tags' do
     it "returns only tags where the tag's tag type matches" do


### PR DESCRIPTION
This prevented creating new records with tags, e.g.

`Record.create!(:tag_string => "haida, carving")`

since the `after_add` hook remove the tagging before it was persisted.

This is a regression I introduced in https://github.com/culturecode/acts_as_taggable/commit/3fcbeabfff7be2d8ed4ba59c26c2b03b4af3630a

The only piece of that old commit that was actually relevant was to reset the association cache when a tag was deleted.